### PR TITLE
feat(renovate): Separate minor/patch grouping for GitHub Actions and pre-commit hooks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -67,8 +67,17 @@
       "groupName": "GitHub artifact actions",
     },
     {
-      "matchManagers": ["github-actions", "pre-commit"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "github-actions-minor-patch",
+      "groupSlug": "github-actions-minor-patch",
+      "automerge": true,
+    },
+    {
+      "matchManagers": ["pre-commit"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "pre-commit-hooks-minor-patch",
+      "groupSlug": "pre-commit-hooks-minor-patch",
       "automerge": true,
     },
     {


### PR DESCRIPTION
This PR separates the grouping of minor and patch updates for GitHub Actions and pre-commit hooks in Renovate configuration.